### PR TITLE
Fix mkdocs documentation build

### DIFF
--- a/docs/agents/amigo_agent.md
+++ b/docs/agents/amigo_agent.md
@@ -1,4 +1,4 @@
 # amigo_agent
 
-::: aurelian.agents.amigo_agent
+::: aurelian.agents.amigo.amigo_agent
 

--- a/docs/agents/chemistry_agent.md
+++ b/docs/agents/chemistry_agent.md
@@ -1,4 +1,4 @@
 # chemistry_agent
 
-::: aurelian.agents.chemistry_agent
+::: aurelian.agents.chemistry.chemistry_agent
 

--- a/docs/agents/gocam_agent.md
+++ b/docs/agents/gocam_agent.md
@@ -1,3 +1,3 @@
 # GO-CAM Agent
 
-::: aurelian.agents.gocam_agent
+::: aurelian.agents.gocam.gocam_agent

--- a/docs/agents/linkml_agent.md
+++ b/docs/agents/linkml_agent.md
@@ -1,4 +1,4 @@
 # linkml_agent
 
-::: aurelian.agents.linkml_agent
+::: aurelian.agents.linkml.linkml_agent
 

--- a/docs/agents/phenopacket_agent.md
+++ b/docs/agents/phenopacket_agent.md
@@ -1,4 +1,4 @@
 # phenopacket_agent
 
-::: aurelian.agents.phenopacket_agent
+::: aurelian.agents.phenopackets.phenopackets_agent
 

--- a/docs/agents/ubergraph_agent.md
+++ b/docs/agents/ubergraph_agent.md
@@ -1,5 +1,7 @@
 # UberGraph Agent
 
+::: aurelian.agents.ubergraph.ubergraph_agent
+
 The UberGraph agent provides a natural language interface to query ontologies using SPARQL through the UberGraph endpoint. It helps users formulate and execute SPARQL queries without needing to know the full SPARQL syntax.
 
 ## Features

--- a/docs/agents/uniprot_agent.md
+++ b/docs/agents/uniprot_agent.md
@@ -1,5 +1,7 @@
 # UniProt Agent
 
+::: aurelian.agents.uniprot.uniprot_agent
+
 The UniProt agent provides an interface to the UniProt database, allowing you to search for proteins, retrieve detailed information about specific proteins, and map between different database identifiers.
 
 ## Features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - biblio_agent: agents/biblio_agent.md
       - checklist_agent: agents/checklist_agent.md
       - chemistry_agent: agents/chemistry_agent.md
+      - d4d_agent: agents/d4d_agent.md
       - diagnosis_agent: agents/diagnosis_agent.md
       - gocam_agent: agents/gocam_agent.md
       - linkml_agent: agents/linkml_agent.md
@@ -61,6 +62,5 @@ nav:
       - uniprot_agent: agents/uniprot_agent.md
 
   - Command Line: cli.md
-  - Test Results: test_results.md
   - Examples:
       - Chemistry: examples/Terpenoids.ipynb


### PR DESCRIPTION
- Updated module paths in agent documentation to match refactored directory structure
- Removed non-existent test_results.md from navigation
- Added d4d_agent to navigation
- Fixed documentation imports for agents to reference new module paths
- Added module imports to ubergraph_agent and uniprot_agent docs

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>