### PR TITLE
Add MCP configuration generator and documentation

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,148 @@
+# Model Context Protocol (MCP) Integration
+
+This document describes how to set up and use [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) with Aurelian agents.
+
+## What is MCP?
+
+MCP (Model Context Protocol) is an open protocol that standardizes how applications provide context to LLMs. It works like a "USB-C port for AI applications," providing a standardized way to connect AI models to different data sources and tools.
+
+### Key benefits:
+
+- Connect LLMs to pre-built integrations with a standard protocol
+- Flexibility to switch between LLM providers
+- Secure your data within your infrastructure
+- Enable complex agent workflows
+
+## Setting Up MCP Servers for Aurelian
+
+Aurelian provides MCP server implementations for several of its agents. You can use these servers to expose Aurelian's capabilities to any MCP-compatible client (such as Claude).
+
+### Configuration Options
+
+You can configure MCP servers in two ways:
+
+1. **Manual Configuration**: Create the full JSON configuration directly
+2. **Generated Configuration**: Use the provided config generator script
+
+### Option 1: Manual Configuration
+
+Create a file named `mcp-config.json` with your server configurations:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
+      "env": {
+        "MEMORY_FILE_PATH": "~/.mcp/memory.json"
+      }
+    },
+    "linkml": {
+      "command": "python",
+      "args": [
+        "/path/to/aurelian/src/aurelian/agents/linkml/linkml_mcp.py"
+      ],
+      "env": {
+        "AURELIAN_WORKDIR": "/tmp/linkml"
+      }
+    }
+  }
+}
+```
+
+### Option 2: Generated Configuration
+
+1. Create a simplified configuration file (e.g., `simple-config.json`):
+
+```json
+{
+  "memory": {
+    "type": "memory",
+    "memory_path": "~/.mcp/memory.json"
+  },
+  "linkml": {
+    "type": "linkml",
+    "workdir": "/tmp/linkml",
+    "python_path": "/usr/bin/python"
+  }
+}
+```
+
+2. Generate the full configuration:
+
+```bash
+python src/aurelian/mcp/config_generator.py --config simple-config.json --output mcp-config.json --base-dir /path/to/aurelian
+```
+
+### Available Agent Servers
+
+Aurelian provides the following MCP servers:
+
+| Server Name   | Type          | Description                                        |
+|---------------|---------------|----------------------------------------------------|
+| linkml        | Agent         | LinkML schema validation and data modeling         |
+| gocam         | Agent         | Gene Ontology Causal Activity Models               |
+| phenopackets  | Agent         | Working with phenotype data in Phenopacket format  |
+| robot         | Agent         | Ontology manipulation with ROBOT                   |
+| amigo         | Agent         | Gene Ontology and gene associations                |
+| uniprot       | Agent         | UniProt protein information                        |
+| memory        | Utility       | Persistent memory for MCP interactions             |
+
+### Configuration Parameters
+
+#### Common Parameters for Agent Servers
+
+- `type`: The agent type (e.g., "linkml", "gocam")
+- `workdir`: Directory for the agent to store files (default: `/tmp/{agent_type}`)
+- `python_path`: Path to Python executable (default: `/usr/bin/python`)
+- `email`: Email address for services that require it (optional)
+- `doi_urls`: DOI URL pattern for literature-related agents (optional)
+- `env`: Additional environment variables (optional)
+
+#### Memory Server Parameters
+
+- `type`: Always "memory"
+- `memory_path`: Path to store memory file (default: `~/.mcp/memory.json`)
+
+#### Custom Server Parameters
+
+- `type`: "custom"
+- `command`: Executable command
+- `args`: List of command arguments
+- `env`: Environment variables dictionary
+
+## Running MCP with Claude
+
+1. Install the MCP CLI:
+
+```bash
+npm install -g @modelcontextprotocol/cli
+```
+
+2. Start the MCP servers:
+
+```bash
+mcp start --config mcp-config.json
+```
+
+3. Open Claude and ensure MCP is enabled in settings
+
+4. In Claude, you can now interact with your Aurelian agents through MCP
+
+## Example Use Cases
+
+- **LinkML Validation**: Use Claude to validate data against LinkML schemas
+- **Ontology Management**: Create and manipulate ontologies through natural language
+- **Gene Association Analysis**: Ask questions about gene functions and associations
+- **Phenotype Analysis**: Work with structured phenotype data
+
+## Troubleshooting
+
+- Ensure the correct Python environment is activated for each server
+- Check server logs for errors by running `mcp logs`
+- Verify paths in your configuration are correct and accessible
+- Ensure required environment variables are set properly

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - uniprot_agent: agents/uniprot_agent.md
 
   - Command Line: cli.md
+  - MCP Integration: mcp.md
   - Test Results: test_results.md
   - Examples:
       - Chemistry: examples/Terpenoids.ipynb

--- a/src/aurelian/mcp/config_generator.py
+++ b/src/aurelian/mcp/config_generator.py
@@ -49,7 +49,7 @@ class MCPConfigGenerator:
                 }
             elif server_type in ["linkml", "gocam", "phenopackets", "robot", "amigo", "uniprot"]:
                 # Aurelian agent MCP server
-                agent_script = f"/src/aurelian/agents/{server_type}/{server_type}_mcp.py"
+                agent_script = f"src/aurelian/agents/{server_type}/{server_type}_mcp.py"
                 workdir = server_config.get("workdir", f"/tmp/{server_type}")
 
                 # Construct environment variables

--- a/src/aurelian/mcp/config_generator.py
+++ b/src/aurelian/mcp/config_generator.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""
+MCP Configuration Generator
+
+Utility script to generate Model Context Protocol (MCP) server configuration from a simplified input.
+"""
+
+import json
+import os
+import argparse
+from typing import Dict, Optional, Any
+from pathlib import Path
+
+
+class MCPConfigGenerator:
+    """Generator for MCP server configuration."""
+
+    def __init__(self, base_dir: Optional[str] = None):
+        """
+        Initialize the MCP config generator.
+
+        Args:
+            base_dir: Base directory for resolving relative paths (defaults to current working directory)
+        """
+        self.base_dir = base_dir or os.getcwd()
+
+    def generate_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Generate a full MCP server configuration from a simplified config.
+
+        Args:
+            config: Simplified configuration dictionary
+
+        Returns:
+            Complete MCP server configuration
+        """
+        mcp_servers = {}
+
+        for server_name, server_config in config.items():
+            server_type = server_config.get("type", "custom")
+
+            if server_type == "memory":
+                # Memory server configuration
+                memory_path = server_config.get("memory_path", os.path.expanduser("~/.mcp/memory.json"))
+                mcp_servers[server_name] = {
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-memory"],
+                    "env": {"MEMORY_FILE_PATH": memory_path},
+                }
+            elif server_type in ["linkml", "gocam", "phenopackets", "robot", "amigo", "uniprot"]:
+                # Aurelian agent MCP server
+                agent_script = f"/src/aurelian/agents/{server_type}/{server_type}_mcp.py"
+                workdir = server_config.get("workdir", f"/tmp/{server_type}")
+
+                # Construct environment variables
+                env = {"AURELIAN_WORKDIR": workdir}
+
+                # Add optional environment variables
+                if "email" in server_config:
+                    env["EMAIL"] = server_config["email"]
+                if "doi_urls" in server_config:
+                    env["DOI_FULL_TEXT_URLS"] = server_config["doi_urls"]
+
+                # Add any additional env vars from config
+                if "env" in server_config:
+                    env.update(server_config["env"])
+
+                script_path = str(Path(self.base_dir) / agent_script)
+                mcp_servers[server_name] = {
+                    "command": server_config.get("python_path", "/usr/bin/python"),
+                    "args": [script_path],
+                    "env": env,
+                }
+            elif server_type == "custom":
+                # Custom server configuration (direct passthrough)
+                mcp_servers[server_name] = {
+                    "command": server_config["command"],
+                    "args": server_config["args"],
+                    "env": server_config.get("env", {}),
+                }
+
+        return {"mcpServers": mcp_servers}
+
+    def write_config(self, config: Dict[str, Any], output_path: str) -> None:
+        """
+        Write the generated configuration to a file.
+
+        Args:
+            config: The simplified configuration dictionary
+            output_path: Path to write the generated configuration
+        """
+        full_config = self.generate_config(config)
+
+        with open(output_path, "w") as f:
+            json.dump(full_config, f, indent=2)
+
+        print(f"MCP configuration written to {output_path}")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Generate MCP server configuration")
+    parser.add_argument("--config", "-c", required=True, help="Path to simplified config file")
+    parser.add_argument("--output", "-o", required=True, help="Path to write generated config")
+    parser.add_argument("--base-dir", "-b", help="Base directory for resolving paths")
+    return parser.parse_args()
+
+
+def main():
+    """Main entrypoint."""
+    args = parse_args()
+
+    # Load simplified config
+    with open(args.config) as f:
+        config = json.load(f)
+
+    # Generate and write config
+    generator = MCPConfigGenerator(base_dir=args.base_dir)
+    generator.write_config(config, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aurelian/mcp/example_config.json
+++ b/src/aurelian/mcp/example_config.json
@@ -1,0 +1,38 @@
+{
+  "memory": {
+    "type": "memory",
+    "memory_path": "~/.mcp/memory.json"
+  },
+  "linkml": {
+    "type": "linkml",
+    "workdir": "/tmp/linkml",
+    "python_path": "/usr/bin/python"
+  },
+  "gocam": {
+    "type": "gocam",
+    "workdir": "/tmp/gocam",
+    "email": "user@example.com",
+    "doi_urls": "https://example.com/doi-resolver",
+    "python_path": "/usr/bin/python"
+  },
+  "phenopackets": {
+    "type": "phenopackets",
+    "workdir": "/tmp/phenopackets",
+    "email": "user@example.com",
+    "python_path": "/usr/bin/python"
+  },
+  "robot": {
+    "type": "robot",
+    "workdir": "/tmp/robot",
+    "python_path": "/usr/bin/python"
+  },
+  "custom_server": {
+    "type": "custom",
+    "command": "/path/to/executable",
+    "args": ["arg1", "arg2"],
+    "env": {
+      "ENV_VAR1": "value1",
+      "ENV_VAR2": "value2"
+    }
+  }
+}

--- a/src/aurelian/mcp/generate_sample_config.py
+++ b/src/aurelian/mcp/generate_sample_config.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""
+Example script to generate a sample MCP configuration file using the config generator.
+"""
+
+import os
+import json
+from pathlib import Path
+from config_generator import MCPConfigGenerator
+
+# Define the base directory for Aurelian
+aurelian_dir = Path(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
+print(f"Aurelian directory: {aurelian_dir}")
+
+# Create a simple configuration
+simple_config = {
+    "memory": {"type": "memory", "memory_path": "~/.mcp/memory.json"},
+    "linkml": {"type": "linkml", "workdir": "/tmp/linkml"},
+    "gocam": {
+        "type": "gocam",
+        "workdir": "/tmp/gocam",
+        "email": "user@example.com",
+        "doi_urls": "https://example.com/doi-resolver",
+    },
+}
+
+# Generate the configuration
+generator = MCPConfigGenerator(base_dir=str(aurelian_dir))
+full_config = generator.generate_config(simple_config)
+
+# Write to a file
+output_path = aurelian_dir / "mcp-config.json"
+with open(output_path, "w") as f:
+    json.dump(full_config, f, indent=2)
+
+print(f"Generated MCP configuration at: {output_path}")
+print("Use with: mcp start --config mcp-config.json")


### PR DESCRIPTION
## Summary
- Add a Python script to generate MCP configuration from a simplified format
- Create example config and sample generator script 
- Add comprehensive MCP documentation with setup instructions
- Update mkdocs.yml to include MCP documentation in navigation

## Test plan
- Run config generator script with example input
- Generate sample MCP config with generate_sample_config.py
- Build docs with `poetry run mkdocs build` to verify documentation

🤖 Generated with [Claude Code](https://claude.ai/code)