### PR TITLE
Add MCP implementation for diagnosis agent

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -90,6 +90,7 @@ Aurelian provides the following MCP servers:
 | robot         | Agent         | Ontology manipulation with ROBOT                   |
 | amigo         | Agent         | Gene Ontology and gene associations                |
 | uniprot       | Agent         | UniProt protein information                        |
+| diagnosis     | Agent         | Disease diagnosis with Monarch Knowledge Graph     |
 | memory        | Utility       | Persistent memory for MCP interactions             |
 
 ### Configuration Parameters

--- a/src/aurelian/agents/diagnosis/diagnosis_mcp.py
+++ b/src/aurelian/agents/diagnosis/diagnosis_mcp.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""
+MCP tools for performing diagnoses, validated against Monarch KG.
+"""
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.filesystem.filesystem_tools as fst
+from aurelian.agents.diagnosis.diagnosis_agent import DIAGNOSIS_SYSTEM_PROMPT
+from aurelian.agents.diagnosis.diagnosis_config import DiagnosisDependencies, get_config
+from aurelian.agents.diagnosis.diagnosis_tools import (
+    find_disease_id,
+    find_disease_phenotypes,
+)
+from aurelian.utils.search_utils import web_search, retrieve_web_page as fetch_web_page
+from aurelian.dependencies.workdir import WorkDir
+
+# Initialize FastMCP server
+mcp = FastMCP("diagnosis", instructions=DIAGNOSIS_SYSTEM_PROMPT)
+
+def deps() -> DiagnosisDependencies:
+    """Get diagnosis dependencies with workdir from environment."""
+    deps = DiagnosisDependencies()
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/diagnosis")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+@mcp.tool()
+async def search_disease(query: str) -> list:
+    """
+    Find diseases matching a search query.
+
+    Args:
+        query: The search term or expression to find diseases
+
+    Returns:
+        List of matching disease IDs and labels
+    """
+    return await find_disease_id(deps(), query)
+
+@mcp.tool()
+async def get_disease_phenotypes(disease_id: str) -> list:
+    """
+    Get phenotypes associated with a disease.
+
+    Args:
+        disease_id: The disease ID (e.g., "MONDO:0007947") or label
+
+    Returns:
+        List of phenotype associations for the disease
+    """
+    return await find_disease_phenotypes(deps(), disease_id)
+
+@mcp.tool()
+async def search_web(query: str) -> str:
+    """
+    Search the web using a text query.
+
+    Note: This will not retrieve the full content. For that, use `retrieve_web_page`.
+
+    Args:
+        query: The search query
+
+    Returns:
+        Matching web pages plus summaries
+    """
+    return web_search(query)
+
+@mcp.tool()
+async def retrieve_web_page(url: str) -> str:
+    """
+    Fetch the contents of a web page.
+
+    Args:
+        url: The URL of the web page to retrieve
+
+    Returns:
+        The contents of the web page
+    """
+    return fetch_web_page(url)
+
+@mcp.tool()
+async def inspect_file(file_name: str) -> str:
+    """
+    Inspect a file in the working directory.
+
+    Args:
+        file_name: name of file to inspect
+
+    Returns:
+        File contents as string
+    """
+    return await fst.inspect_file(deps(), file_name)
+
+@mcp.tool()
+async def list_files() -> str:
+    """
+    List files in the working directory.
+
+    Returns:
+        Newline-separated list of file names
+    """
+    return "\n".join(deps().workdir.list_file_names())
+
+@mcp.tool()
+async def write_to_file(data: str, file_name: str) -> str:
+    """
+    Write data to a file in the working directory.
+
+    Args:
+        data: Content to write
+        file_name: Target file name
+
+    Returns:
+        Confirmation message
+    """
+    print(f"Writing data to file: {file_name}")
+    deps().workdir.write_file(file_name, data)
+    return f"Data written to {file_name}"
+
+@mcp.tool()
+async def download_web_page(url: str, local_file_name: str) -> str:
+    """
+    Download contents of a web page to a local file.
+
+    Args:
+        url: URL of the web page
+        local_file_name: Name of the local file to save to
+
+    Returns:
+        Confirmation message
+    """
+    print(f"Fetch URL: {url}")
+    data = fetch_web_page(url)
+    deps().workdir.write_file(local_file_name, data)
+    return f"Data written to {local_file_name}"
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/mcp/config_generator.py
+++ b/src/aurelian/mcp/config_generator.py
@@ -47,7 +47,7 @@ class MCPConfigGenerator:
                     "args": ["-y", "@modelcontextprotocol/server-memory"],
                     "env": {"MEMORY_FILE_PATH": memory_path},
                 }
-            elif server_type in ["linkml", "gocam", "phenopackets", "robot", "amigo", "uniprot"]:
+            elif server_type in ["linkml", "gocam", "phenopackets", "robot", "amigo", "uniprot", "diagnosis"]:
                 # Aurelian agent MCP server
                 agent_script = f"/src/aurelian/agents/{server_type}/{server_type}_mcp.py"
                 workdir = server_config.get("workdir", f"/tmp/{server_type}")

--- a/src/aurelian/mcp/example_config.json
+++ b/src/aurelian/mcp/example_config.json
@@ -26,6 +26,11 @@
     "workdir": "/tmp/robot",
     "python_path": "/usr/bin/python"
   },
+  "diagnosis": {
+    "type": "diagnosis",
+    "workdir": "/tmp/diagnosis",
+    "python_path": "/usr/bin/python"
+  },
   "custom_server": {
     "type": "custom",
     "command": "/path/to/executable",

--- a/src/aurelian/mcp/mcp_discovery.py
+++ b/src/aurelian/mcp/mcp_discovery.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Script for discovering and testing MCP implementations.
+"""
+
+import argparse
+import importlib
+import inspect
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+def list_mcp_tools(module_path: str) -> List[str]:
+    """
+    List all MCP tools in a given module.
+    
+    Args:
+        module_path: Dot-separated path to the module
+        
+    Returns:
+        List of tool names
+    """
+    try:
+        # Import the module
+        module = importlib.import_module(module_path)
+        
+        # Find the MCP server instance
+        mcp = getattr(module, "mcp", None)
+        if not mcp:
+            print(f"No 'mcp' instance found in {module_path}")
+            return []
+        
+        # Get all functions with the MCP tool decorator
+        tools = []
+        for name, func in inspect.getmembers(module, inspect.isfunction):
+            # Check if this function is an MCP tool
+            if hasattr(func, "__mcp_tool__") and func.__mcp_tool__ is True:
+                tools.append(name)
+                
+        return tools
+    except Exception as e:
+        print(f"Error importing {module_path}: {e}")
+        return []
+
+
+def main():
+    """Command line interface."""
+    parser = argparse.ArgumentParser(description="Discover and test MCP implementations")
+    parser.add_argument("--agent", "-a", help="Agent type to test (e.g., 'diagnosis')")
+    parser.add_argument("--list", "-l", action="store_true", help="List available MCP modules")
+    args = parser.parse_args()
+    
+    # Base path for agent modules
+    base_path = Path(__file__).parent.parent
+    
+    if args.list:
+        # List all MCP modules
+        agents_dir = base_path / "agents"
+        print("Available MCP modules:")
+        for agent_dir in agents_dir.iterdir():
+            if agent_dir.is_dir():
+                mcp_file = agent_dir / f"{agent_dir.name}_mcp.py"
+                if mcp_file.exists():
+                    print(f"  - {agent_dir.name}")
+        return
+        
+    if not args.agent:
+        print("Error: Please specify an agent type with --agent")
+        sys.exit(1)
+        
+    # Check if the MCP module exists
+    agent_type = args.agent
+    module_path = f"aurelian.agents.{agent_type}.{agent_type}_mcp"
+    
+    # List the tools
+    tools = list_mcp_tools(module_path)
+    if tools:
+        print(f"MCP tools for {agent_type}:")
+        for tool in tools:
+            print(f"  - {tool}")
+    else:
+        print(f"No MCP tools found for {agent_type}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add MCP server implementation for the diagnosis agent to expose disease diagnosis capabilities via MCP
- Update configuration generator to support the diagnosis agent type
- Create MCP discovery tool to list available MCP agents and their exposed tools
- Update MCP documentation to include the diagnosis agent server

This PR demonstrates how to implement MCP for additional agents, as a follow-up to the MCP configuration generator PR.

## Test plan
- Run the MCP discovery tool to verify it finds the diagnosis agent: `python src/aurelian/mcp/mcp_discovery.py --agent diagnosis`
- Test the diagnosis MCP server with `mcp run --stdio "python src/aurelian/agents/diagnosis/diagnosis_mcp.py"`
- Generate a config including the diagnosis server with the config generator

🤖 Generated with [Claude Code](https://claude.ai/code)