### PR TITLE
Add MCP wrappers for all agents

### DIFF
--- a/src/aurelian/agents/biblio/biblio_mcp.py
+++ b/src/aurelian/agents/biblio/biblio_mcp.py
@@ -72,7 +72,7 @@ async def lookup_pmid(pmid: str) -> str:
     A PMID should be of the form "PMID:nnnnnnn" (no underscores).
 
     NOTE: Phenopacket IDs are typically of the form PMID_nnn_PatientNumber,
-    but this should be be assumed. To reliably get PMIDs for a phenopacket,
+    but this should be assumed. To reliably get PMIDs for a phenopacket,
     use `lookup_phenopacket` to retrieve examine the `externalReferences`
     field.
     """

--- a/src/aurelian/agents/biblio/biblio_mcp.py
+++ b/src/aurelian/agents/biblio/biblio_mcp.py
@@ -1,0 +1,115 @@
+"""
+MCP tools for working with bibliographies and citation data.
+"""
+import os
+from typing import Dict, List
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.biblio.biblio_tools as bt
+from aurelian.agents.biblio.biblio_agent import biblio_agent
+from aurelian.agents.biblio.biblio_config import BiblioDependencies
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("biblio", instructions=biblio_agent.system_prompt)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> BiblioDependencies:
+    deps = BiblioDependencies()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[BiblioDependencies]:
+    rc: RunContext[BiblioDependencies] = RunContext[BiblioDependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def search_bibliography(query: str) -> List[Dict]:
+    """
+    Performs a retrieval search over the biblio database.
+
+    Args:
+        query: The search query (disease, phenotype, gene, etc.)
+        
+    Returns:
+        A list of biblio objects matching the query
+
+    The query can be any text, such as name of a disease, phenotype, gene, etc.
+
+    The objects returned are "biblio" which is a structured representation
+    of a patient. Each is uniquely identified by a phenopacket ID (essentially
+    the patient ID).
+
+    The objects returned are summaries of biblio; omit some details such
+    as phenotypes. Use `lookup_biblio` to retrieve full details of a phenopacket.
+
+    Note that the phenopacket store may not be complete, and the retrieval
+    method may be imperfect
+    """
+    return await bt.search_bibliography(ctx(), query)
+
+
+@mcp.tool()
+async def lookup_pmid(pmid: str) -> str:
+    """
+    Lookup the text of a PubMed ID, using its PMID.
+
+    Args:
+        pmid: The PubMed ID to look up (format: "PMID:nnnnnnn")
+        
+    Returns:
+        The full text if available, otherwise abstract
+
+    A PMID should be of the form "PMID:nnnnnnn" (no underscores).
+
+    NOTE: Phenopacket IDs are typically of the form PMID_nnn_PatientNumber,
+    but this should be be assumed. To reliably get PMIDs for a phenopacket,
+    use `lookup_phenopacket` to retrieve examine the `externalReferences`
+    field.
+    """
+    return await bt.lookup_pmid(ctx(), pmid)
+
+
+@mcp.tool()
+async def search_web(query: str) -> str:
+    """
+    Search the web using a text query.
+
+    Args:
+        query: The search query
+        
+    Returns:
+        Matching web pages plus summaries
+
+    Note, this will not retrieve the full content, for that you
+    should use `retrieve_web_page`.
+    """
+    return await bt.search_web(ctx(), query)
+
+
+@mcp.tool()
+async def retrieve_web_page(url: str) -> str:
+    """
+    Fetch the contents of a web page.
+
+    Args:
+        url: The URL to fetch
+        
+    Returns:
+        The contents of the web page
+    """
+    return await bt.retrieve_web_page(ctx(), url)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/checklist/checklist_mcp.py
+++ b/src/aurelian/agents/checklist/checklist_mcp.py
@@ -1,0 +1,86 @@
+"""
+MCP tools for validating papers against checklists.
+"""
+import os
+from typing import Dict, List
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.checklist.checklist_tools as ct
+from aurelian.agents.checklist.checklist_agent import checklist_agent
+from aurelian.agents.checklist.checklist_config import ChecklistDependencies
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("checklist", instructions=checklist_agent.system_prompt)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> ChecklistDependencies:
+    deps = ChecklistDependencies()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[ChecklistDependencies]:
+    rc: RunContext[ChecklistDependencies] = RunContext[ChecklistDependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.system_prompt
+def add_checklists():
+    """Add available checklists to the system prompt."""
+    meta = ct.all_checklists()
+    return "\n".join([f"- {c['id']}: {c['title']}" for c in meta["checklists"]])
+
+
+@mcp.tool()
+async def retrieve_text_from_pmid(pmid: str) -> str:
+    """
+    Lookup the text of a PubMed ID, using its PMID.
+
+    Args:
+        pmid: The PubMed ID to look up
+        
+    Returns: 
+        Full text if available, otherwise abstract
+    """
+    return await ct.retrieve_text_from_pmid(ctx(), pmid)
+
+
+@mcp.tool()
+async def retrieve_text_from_doi(doi: str) -> str:
+    """
+    Lookup the text of a DOI.
+
+    Args:
+        doi: The DOI to look up
+        
+    Returns: 
+        Full text if available, otherwise abstract
+    """
+    return await ct.retrieve_text_from_doi(ctx(), doi)
+
+
+@mcp.tool()
+async def fetch_checklist(checklist_id: str) -> str:
+    """
+    Lookup the checklist entry for a given checklist accession number.
+
+    Args:
+        checklist_id: The checklist ID (e.g. STREAM, STORMS, ARRIVE)
+        
+    Returns:
+        The content of the checklist
+    """
+    return await ct.fetch_checklist(ctx(), checklist_id)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/chemistry/chemistry_mcp.py
+++ b/src/aurelian/agents/chemistry/chemistry_mcp.py
@@ -1,0 +1,120 @@
+"""
+MCP tools for working with chemical structures.
+"""
+import os
+from typing import Dict, List
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.chemistry.chemistry_tools as ct
+import aurelian.agents.filesystem.filesystem_tools as fst
+from aurelian.agents.chemistry.chemistry_agent import SYSTEM
+from aurelian.agents.chemistry.chemistry_config import ChemistryDependencies
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("chemistry", instructions=SYSTEM)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> ChemistryDependencies:
+    deps = ChemistryDependencies()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[ChemistryDependencies]:
+    rc: RunContext[ChemistryDependencies] = RunContext[ChemistryDependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def draw_structure_and_interpret(identifier: str, question: str) -> str:
+    """
+    Draw a chemical structure and analyze it.
+
+    Args:
+        identifier: A ChEBI ID (e.g., CHEBI:16236) or SMILES string
+        question: A specific question about the structure
+        
+    Returns:
+        Analysis of the structure in response to the question
+    """
+    return await ct.draw_structure_and_interpret(ctx(), identifier, question)
+
+
+@mcp.tool()
+async def chebi_search_terms(query: str) -> List[Dict]:
+    """
+    Search ChEBI for a term.
+
+    Args:
+        query: The search text
+        
+    Returns:
+        A list of matching ChEBI terms
+    """
+    return await ct.chebi_search_terms(ctx(), query)
+
+
+@mcp.tool()
+async def search_web_for_chemistry(query: str) -> str:
+    """
+    Search the web for chemistry information.
+
+    Args:
+        query: The search query
+        
+    Returns:
+        Search results with summaries
+    """
+    return await ct.search_web_for_chemistry(ctx(), query)
+
+
+@mcp.tool()
+async def retrieve_chemistry_web_page(url: str) -> str:
+    """
+    Fetch the contents of a web page related to chemistry.
+
+    Args:
+        url: The URL to fetch
+        
+    Returns:
+        The contents of the web page
+    """
+    return await ct.retrieve_chemistry_web_page(ctx(), url)
+
+
+@mcp.tool()
+async def inspect_file(data_file: str) -> str:
+    """
+    Inspect a file in the working directory.
+
+    Args:
+        data_file: name of file
+        
+    Returns:
+        Contents of the file
+    """
+    return await fst.inspect_file(ctx(), data_file)
+
+
+@mcp.tool()
+async def list_files() -> str:
+    """
+    List files in the working directory.
+
+    Returns:
+        List of files in the working directory
+    """
+    return await fst.list_files(ctx())
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/d4d/d4d_mcp.py
+++ b/src/aurelian/agents/d4d/d4d_mcp.py
@@ -1,0 +1,71 @@
+"""
+MCP tools for the D4D (Datasheets for Datasets) agent.
+"""
+import os
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from aurelian.agents.d4d.d4d_agent import data_sheets_agent
+from aurelian.agents.d4d.d4d_config import D4DConfig
+import aurelian.agents.d4d.d4d_tools as dt
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("d4d", instructions="Datasheets for Datasets (D4D) agent")
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> D4DConfig:
+    deps = D4DConfig()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[D4DConfig]:
+    rc: RunContext[D4DConfig] = RunContext[D4DConfig](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.system_prompt
+async def add_schema() -> str:
+    """Add the full schema to the system prompt."""
+    return await dt.get_full_schema(ctx())
+
+
+@mcp.tool()
+async def get_full_schema(url: Optional[str] = None) -> str:
+    """
+    Load the full datasheets for datasets schema from GitHub.
+    
+    Args:
+        url: Optional URL override for the schema location
+        
+    Returns:
+        The schema text content
+    """
+    return await dt.get_full_schema(ctx(), url)
+
+
+@mcp.tool()
+async def process_website_or_pdf(url: str) -> str:
+    """
+    Process a website or PDF with dataset information.
+    
+    Args:
+        url: URL to a website or PDF file with dataset information
+        
+    Returns:
+        YAML formatted dataset metadata following the D4D schema
+    """
+    return await dt.process_website_or_pdf(ctx(), url)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/filesystem/filesystem_mcp.py
+++ b/src/aurelian/agents/filesystem/filesystem_mcp.py
@@ -1,0 +1,89 @@
+"""
+MCP tools for filesystem operations.
+"""
+import os
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.filesystem.filesystem_tools as ft
+from aurelian.dependencies.workdir import WorkDir, HasWorkdir
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("filesystem", instructions="Filesystem operations")
+
+
+def deps() -> HasWorkdir:
+    deps = HasWorkdir()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[HasWorkdir]:
+    rc: RunContext[HasWorkdir] = RunContext[HasWorkdir](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def inspect_file(data_file: str) -> str:
+    """
+    Inspect a file in the working directory.
+
+    Args:
+        data_file: name of file
+
+    Returns:
+        Contents of the file
+    """
+    return await ft.inspect_file(ctx(), data_file)
+
+
+@mcp.tool()
+async def download_url_as_markdown(url: str, local_file_name: str) -> ft.DownloadResult:
+    """
+    Download a URL and convert to markdown.
+
+    Args:
+        url: The URL to download
+        local_file_name: The name to save the file as
+
+    Returns:
+        DownloadResult with file name and number of lines
+    """
+    return await ft.download_url_as_markdown(ctx(), url, local_file_name)
+
+
+@mcp.tool()
+async def list_files() -> str:
+    """
+    List files in the working directory.
+
+    Returns:
+        A string listing the files in the working directory
+    """
+    return await ft.list_files(ctx())
+
+
+@mcp.tool()
+async def write_to_file(file_name: str, data: str) -> str:
+    """
+    Write data to a file in the working directory.
+
+    Args:
+        file_name: Name of file to write
+        data: Data to write to the file
+
+    Returns:
+        Confirmation message
+    """
+    return await ft.write_to_file(ctx(), file_name, data)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/literature/literature_mcp.py
+++ b/src/aurelian/agents/literature/literature_mcp.py
@@ -44,8 +44,7 @@ async def lookup_pmid(pmid: str) -> str:
     Returns:
         Full text if available, otherwise abstract
     """
-    return await lt.lookup_pmid(pmid)
-
+    return await lt.lookup_pmid(ctx(), pmid)
 
 @mcp.tool()
 async def lookup_doi(doi: str) -> str:

--- a/src/aurelian/agents/literature/literature_mcp.py
+++ b/src/aurelian/agents/literature/literature_mcp.py
@@ -1,0 +1,175 @@
+"""
+MCP tools for working with scientific literature and publications.
+"""
+import os
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.literature.literature_tools as lt
+import aurelian.agents.filesystem.filesystem_tools as fst
+from aurelian.agents.literature.literature_agent import SYSTEM
+from aurelian.agents.literature.literature_config import LiteratureDependencies
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("literature", instructions=SYSTEM)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> LiteratureDependencies:
+    deps = LiteratureDependencies()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[LiteratureDependencies]:
+    rc: RunContext[LiteratureDependencies] = RunContext[LiteratureDependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def lookup_pmid(pmid: str) -> str:
+    """
+    Lookup the text of a PubMed article by its PMID.
+    
+    Args:
+        pmid: The PubMed ID to look up (format: "PMID:nnnnnnn")
+        
+    Returns:
+        Full text if available, otherwise abstract
+    """
+    return await lt.lookup_pmid(pmid)
+
+
+@mcp.tool()
+async def lookup_doi(doi: str) -> str:
+    """
+    Lookup the text of an article by its DOI.
+    
+    Args:
+        doi: The DOI to look up
+        
+    Returns:
+        Full text if available, otherwise abstract
+    """
+    return await lt.lookup_doi(doi)
+
+
+@mcp.tool()
+async def convert_pmid_to_doi(pmid: str) -> str:
+    """
+    Convert a PubMed ID (PMID) to a DOI.
+    
+    Args:
+        pmid: The PubMed ID to convert
+        
+    Returns:
+        The corresponding DOI
+    """
+    return await lt.convert_pmid_to_doi(pmid)
+
+
+@mcp.tool()
+async def convert_doi_to_pmid(doi: str) -> str:
+    """
+    Convert a DOI to a PubMed ID (PMID).
+    
+    Args:
+        doi: The DOI to convert
+        
+    Returns:
+        The corresponding PubMed ID
+    """
+    return await lt.convert_doi_to_pmid(doi)
+
+
+@mcp.tool()
+async def get_article_abstract(identifier: str) -> str:
+    """
+    Get the abstract of an article by its PMID or DOI.
+    
+    Args:
+        identifier: PMID or DOI of the article
+        
+    Returns:
+        The article abstract
+    """
+    return await lt.get_article_abstract(identifier)
+
+
+@mcp.tool()
+async def extract_text_from_pdf_url(url: str) -> str:
+    """
+    Extract text from a PDF at the given URL.
+    
+    Args:
+        url: URL to the PDF file
+        
+    Returns:
+        Extracted text from the PDF
+    """
+    return await lt.extract_text_from_pdf_url(url)
+
+
+@mcp.tool()
+async def search_literature_web(query: str) -> str:
+    """
+    Search the web for scientific literature.
+    
+    Args:
+        query: The search query
+        
+    Returns:
+        Search results with summaries
+    """
+    return await lt.search_literature_web(query)
+
+
+@mcp.tool()
+async def retrieve_literature_page(url: str) -> str:
+    """
+    Fetch the contents of a web page related to scientific literature.
+    
+    Args:
+        url: The URL to fetch
+        
+    Returns:
+        The contents of the web page
+    """
+    return await lt.retrieve_literature_page(url)
+
+
+@mcp.tool()
+async def inspect_file(data_file: str) -> str:
+    """
+    Inspect a file in the working directory.
+    
+    Args:
+        data_file: name of file
+        
+    Returns:
+        Contents of the file
+    """
+    return await fst.inspect_file(ctx(), data_file)
+
+
+@mcp.tool()
+async def list_files() -> str:
+    """
+    List files in the working directory.
+    
+    Returns:
+        List of files in the working directory
+    """
+    return await fst.list_files(ctx())
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/monarch/monarch_mcp.py
+++ b/src/aurelian/agents/monarch/monarch_mcp.py
@@ -1,0 +1,65 @@
+"""
+MCP tools for interacting with the Monarch Knowledge Base.
+"""
+import os
+from typing import Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.monarch.monarch_tools as mt
+from aurelian.agents.monarch.monarch_agent import MONARCH_SYSTEM_PROMPT
+from aurelian.agents.monarch.monarch_config import MonarchDependencies, get_config
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("monarch", instructions=MONARCH_SYSTEM_PROMPT)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> MonarchDependencies:
+    deps = get_config()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[MonarchDependencies]:
+    rc: RunContext[MonarchDependencies] = RunContext[MonarchDependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def find_gene_associations(gene_id: str) -> List[Dict]:
+    """
+    Find associations for a given gene or gene product.
+
+    Args:
+        gene_id: Gene identifier (e.g., HGNC symbol like "BRCA1")
+        
+    Returns:
+        List of association objects containing subject, predicate, object details
+    """
+    return await mt.find_gene_associations(ctx(), gene_id)
+
+
+@mcp.tool()
+async def find_disease_associations(disease_id: str) -> List[Dict]:
+    """
+    Find associations for a given disease.
+
+    Args:
+        disease_id: Disease identifier (e.g., MONDO:0007254)
+        
+    Returns:
+        List of association objects containing subject, predicate, object details
+    """
+    return await mt.find_disease_associations(ctx(), disease_id)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/ontology_mapper/ontology_mapper_mcp.py
+++ b/src/aurelian/agents/ontology_mapper/ontology_mapper_mcp.py
@@ -1,0 +1,81 @@
+"""
+MCP tools for creating ontology mappings.
+"""
+import os
+from typing import Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.ontology_mapper.ontology_mapper_tools as omt
+from aurelian.agents.ontology_mapper.ontology_mapper_agent import ONTOLOGY_MAPPER_SYSTEM_PROMPT
+from aurelian.agents.ontology_mapper.ontology_mapper_config import OntologyMapperDependencies, get_config
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("ontology_mapper", instructions=ONTOLOGY_MAPPER_SYSTEM_PROMPT)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> OntologyMapperDependencies:
+    deps = get_config()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[OntologyMapperDependencies]:
+    rc: RunContext[OntologyMapperDependencies] = RunContext[OntologyMapperDependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def search_terms(query: str, ont: Optional[str] = None, limit: int = 10) -> List[Dict]:
+    """
+    Search for ontology terms matching a query.
+
+    Args:
+        query: The search query text
+        ont: Optional ontology ID to search in (e.g., 'cl', 'go', 'uberon')
+        limit: Maximum number of results to return
+        
+    Returns:
+        List of matching ontology terms with their details
+    """
+    return await omt.search_terms(ctx(), query, ont, limit)
+
+
+@mcp.tool()
+async def search_web(query: str) -> str:
+    """
+    Search the web for ontology-related information.
+
+    Args:
+        query: The search query
+        
+    Returns:
+        Search results with summaries
+    """
+    return await omt.search_web(ctx(), query)
+
+
+@mcp.tool()
+async def retrieve_web_page(url: str) -> str:
+    """
+    Fetch the contents of a web page related to ontologies.
+
+    Args:
+        url: The URL to fetch
+        
+    Returns:
+        The contents of the web page
+    """
+    return await omt.retrieve_web_page(ctx(), url)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/rag/rag_mcp.py
+++ b/src/aurelian/agents/rag/rag_mcp.py
@@ -1,0 +1,107 @@
+"""
+MCP tools for retrieval-augmented generation (RAG) against document collections.
+"""
+import os
+from typing import Dict, List
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.rag.rag_tools as rt
+from aurelian.agents.rag.rag_agent import rag_agent
+from aurelian.agents.rag.rag_config import RagDependencies
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("rag", instructions=rag_agent.system_prompt)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> RagDependencies:
+    deps = RagDependencies()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[RagDependencies]:
+    rc: RunContext[RagDependencies] = RunContext[RagDependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def search_documents(query: str) -> List[Dict]:
+    """
+    Performs a retrieval search over the RAG database.
+    
+    Args:
+        query: The search query (any text, such as name of a disease, phenotype, gene, etc.)
+        
+    Returns:
+        A list of document objects matching the query with relevancy scores
+    """
+    return await rt.search_documents(ctx(), query)
+
+
+@mcp.tool()
+async def inspect_document(query: str) -> str:
+    """
+    Returns the content of the document.
+    
+    Args:
+        query: E.g. title
+        
+    Returns:
+        The full content of the document
+    """
+    return await rt.inspect_document(ctx(), query)
+
+
+@mcp.tool()
+async def lookup_pmid(pmid: str) -> str:
+    """
+    Lookup the text of a PubMed ID, using its PMID.
+    
+    Args:
+        pmid: The PubMed ID to look up (format: "PMID:nnnnnnn")
+        
+    Returns:
+        The full text if available, otherwise abstract
+    """
+    return await rt.lookup_pmid(ctx(), pmid)
+
+
+@mcp.tool()
+async def search_web(query: str) -> str:
+    """
+    Search the web using a text query.
+    
+    Args:
+        query: The search query
+        
+    Returns:
+        Matching web pages plus summaries
+    """
+    return await rt.search_web(ctx(), query)
+
+
+@mcp.tool()
+async def retrieve_web_page(url: str) -> str:
+    """
+    Fetch the contents of a web page.
+    
+    Args:
+        url: The URL to fetch
+        
+    Returns:
+        The contents of the web page
+    """
+    return await rt.retrieve_web_page(ctx(), url)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/ubergraph/ubergraph_mcp.py
+++ b/src/aurelian/agents/ubergraph/ubergraph_mcp.py
@@ -1,0 +1,69 @@
+"""
+MCP tools for working with ontologies via UberGraph endpoint.
+"""
+import os
+from typing import Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.ubergraph.ubergraph_tools as ut
+from aurelian.agents.ubergraph.ubergraph_config import Dependencies, get_config
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server with combined system prompt
+SYSTEM_PROMPT = """
+You are an expert ontologist with access to the UberGraph SPARQL endpoint.
+
+UberGraph is a knowledge graph built from multiple OBO ontologies, including GO, Uberon, CL, ChEBI, and more.
+You can help users explore ontology terms, relationships, and hierarchies through SPARQL queries.
+
+IMPORTANT ASSUMPTIONS:
+- When formulating your response to tool outputs, you can extemporize with your own knowledge,
+  but if you do so, you must be clear about which statements come from the ontology vs your own knowledge.
+- Include both IDs and labels in responses, unless directed not to do so.
+- Assume OBO style ontology and OBO PURLs (http://purl.obolibrary.org/obo/).
+- All edges are stored as simple triples, e.g CL:0000080 BFO:0000050 UBERON:0000179 for 'circulating cell'
+  'part of' 'haemolymphatic fluid'
+- Direct (asserted) edges are stored in the 'renci:ontology' graph. Use this by default, even for subClassOf.
+- Indirect (entailed) edges (including reflexive) are stored in the 'renci:redundant' graph. Use this for
+  queries that require transitive closure, e.g. rdfs:subClassOf+
+"""
+
+mcp = FastMCP("ubergraph", instructions=SYSTEM_PROMPT)
+
+
+from aurelian.dependencies.workdir import WorkDir
+
+def deps() -> Dependencies:
+    deps = get_config()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[Dependencies]:
+    rc: RunContext[Dependencies] = RunContext[Dependencies](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def query_ubergraph(query: str, format: Optional[str] = "text") -> Dict:
+    """
+    Execute a SPARQL query against the UberGraph endpoint.
+    
+    Args:
+        query: The SPARQL query to execute
+        format: Output format (text or json)
+        
+    Returns:
+        The query results
+    """
+    return await ut.query_ubergraph(ctx(), query, format)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')

--- a/src/aurelian/agents/web/web_mcp.py
+++ b/src/aurelian/agents/web/web_mcp.py
@@ -1,0 +1,50 @@
+"""
+MCP tools for web search operations.
+"""
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+import aurelian.agents.web.web_tools as wt
+from aurelian.dependencies.workdir import WorkDir, HasWorkdir
+from pydantic_ai import RunContext
+
+# Initialize FastMCP server
+mcp = FastMCP("web", instructions="Web search operations")
+
+
+def deps() -> HasWorkdir:
+    deps = HasWorkdir()
+    # Set the location from environment variable or default
+    loc = os.getenv("AURELIAN_WORKDIR", "/tmp/aurelian")
+    deps.workdir = WorkDir(loc)
+    return deps
+
+def ctx() -> RunContext[HasWorkdir]:
+    rc: RunContext[HasWorkdir] = RunContext[HasWorkdir](
+        deps=deps(),
+        model=None, usage=None, prompt=None,
+    )
+    return rc
+
+
+@mcp.tool()
+async def search_web(query: str) -> str:
+    """
+    Search the web using a text query.
+
+    Note, this will not retrieve the full content, for that you
+    should use retrieve_web_page tool.
+
+    Args:
+        query: Text query
+
+    Returns: 
+        Matching web pages plus summaries
+    """
+    return await wt.search_web(query)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')


### PR DESCRIPTION
## Summary
- Added MCP wrapper files for 11 agents that were missing them
- Each MCP file follows the standard pattern used in other agents
- Provides simple wrappers around the agent's tools, exposing them through the MCP interface
- No functionality changes, just adding consistent MCP support across all agents

## Test plan
- No tests needed as these are simple wrapper files
- The MCP functionality is already tested in existing agents