### PR TITLE
Add perplexity_query function to web_tools

### DIFF
--- a/docs/examples/Perplexity-Example.ipynb
+++ b/docs/examples/Perplexity-Example.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/TranscriptionFactors.ipynb
+++ b/docs/examples/TranscriptionFactors.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/aurelian/agents/web/web_tools.py
+++ b/src/aurelian/agents/web/web_tools.py
@@ -1,4 +1,30 @@
+from typing import List, Optional
+import os
+import xml.etree.ElementTree as ET
+from pydantic import BaseModel, Field
+
 from aurelian.utils.search_utils import web_search
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIModel
+
+
+class Citation(BaseModel):
+    """Citation model for query results with citations."""
+    
+    citation_number: str = Field(description="Citation number or identifier")
+    url: str = Field(description="URL source of the citation") 
+    timestamp: Optional[str] = Field(
+        default=None, description="Timestamp of the citation, if available"
+    )
+
+
+class ResultWithCitations(BaseModel):
+    """Generic result model for queries that return content with citations."""
+    
+    content: str = Field(description="Content of the response")
+    citations: List[Citation] = Field(
+        default_factory=list, description="List of citations referenced in the content"
+    )
 
 
 async def search_web(query: str) -> str:
@@ -15,3 +41,68 @@ async def search_web(query: str) -> str:
     """
     print(f"Web Search: {query}")
     return web_search(query)
+
+
+async def perplexity_query(query: str, model_name: str = "sonar") -> ResultWithCitations:
+    """
+    Query the Perplexity API and return structured results with citations.
+    
+    Args:
+        query: The query to send to Perplexity
+        model_name: The Perplexity model to use (default: "sonar"). Options include "sonar", "sonar-pro", etc.
+        
+    Returns:
+        ResultWithCitations: A structured response with content and citations
+        
+    Raises:
+        ValueError: If the Perplexity API key is not set
+        RuntimeError: If the response parsing fails
+    """
+    perplexity_api_key = os.environ.get("PERPLEXITY_API_KEY")
+    if not perplexity_api_key:
+        raise ValueError("PERPLEXITY_API_KEY environment variable is not set")
+        
+    sonar_model = OpenAIModel(
+        model_name=model_name,
+        base_url='https://api.perplexity.ai',
+        api_key=perplexity_api_key,
+    )
+    
+    agent = Agent(sonar_model,
+                  system_prompt=("Return the response with xml tags <answer> and <citations>,"
+                                 "where citations includes a list with the citation_number, url,"
+                                 " and timestamp for the retrieved citations"))
+    result = agent.run_sync(query)
+    
+    try:
+        # Parse the XML response
+        xml_string = f"<root>{result.data}</root>"
+        root = ET.fromstring(xml_string)
+        
+        # Extract answer content
+        answer_element = root.find("answer")
+        content = answer_element.text.strip() if answer_element is not None and answer_element.text else ""
+        
+        # Extract citations
+        citations_list = []
+        citations_element = root.find("citations")
+        if citations_element is not None:
+            for citation in citations_element.findall(".//citation"):
+                citation_number = citation.find("citation_number")
+                if citation_number is None:
+                    citation_number = citation.find("number")
+                
+                url_element = citation.find("url")
+                timestamp_element = citation.find("timestamp")
+                
+                citations_list.append(
+                    Citation(
+                        citation_number=citation_number.text if citation_number is not None and citation_number.text else "",
+                        url=url_element.text if url_element is not None and url_element.text else "",
+                        timestamp=timestamp_element.text if timestamp_element is not None and timestamp_element.text else None
+                    )
+                )
+        
+        return ResultWithCitations(content=content, citations=citations_list)
+    except Exception as e:
+        raise RuntimeError(f"Failed to parse Perplexity response: {e}")

--- a/src/aurelian/agents/web/web_tools.py
+++ b/src/aurelian/agents/web/web_tools.py
@@ -104,5 +104,5 @@ async def perplexity_query(query: str, model_name: str = "sonar") -> ResultWithC
                 )
         
         return ResultWithCitations(content=content, citations=citations_list)
-    except Exception as e:
+    except ET.ParseError as e:
         raise RuntimeError(f"Failed to parse Perplexity response: {e}")

--- a/tests/test_agents/test_web_tools.py
+++ b/tests/test_agents/test_web_tools.py
@@ -1,0 +1,176 @@
+"""
+Tests for the web tools.
+"""
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from aurelian.agents.web.web_tools import perplexity_query, ResultWithCitations
+
+
+@pytest.fixture
+def mock_agent():
+    """Fixture to mock the pydantic_ai Agent."""
+    with patch("aurelian.agents.web.web_tools.Agent") as mock_agent_class:
+        mock_instance = MagicMock()
+        mock_agent_class.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.fixture
+def mock_openai_model():
+    """Fixture to mock the OpenAIModel."""
+    with patch("aurelian.agents.web.web_tools.OpenAIModel") as mock_model_class:
+        mock_instance = MagicMock()
+        mock_model_class.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.mark.asyncio
+async def test_perplexity_query(mock_agent, mock_openai_model):
+    """Test the perplexity_query function."""
+    # Setup the mock to return a sample XML response
+    mock_result = MagicMock()
+    mock_result.data = """
+    <answer>
+    This is a test answer about a scientific topic.
+    </answer>
+    <citations>
+      <citation>
+        <citation_number>1</citation_number>
+        <url>https://example.com/citation1</url>
+        <timestamp>2023-01-01</timestamp>
+      </citation>
+      <citation>
+        <citation_number>2</citation_number>
+        <url>https://example.com/citation2</url>
+        <timestamp>2023-01-02</timestamp>
+      </citation>
+    </citations>
+    """
+    mock_agent.run_sync.return_value = mock_result
+    
+    # Set environment variable for test
+    with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test_key"}):
+        # Call the function
+        result = await perplexity_query("Test query about science")
+        
+        # Verify the result
+        assert isinstance(result, ResultWithCitations)
+        assert "test answer about a scientific topic" in result.content
+        assert len(result.citations) == 2
+        assert result.citations[0].citation_number == "1"
+        assert result.citations[0].url == "https://example.com/citation1"
+        assert result.citations[0].timestamp == "2023-01-01"
+        assert result.citations[1].citation_number == "2"
+        assert result.citations[1].url == "https://example.com/citation2"
+        
+        # Verify the mock was called with expected arguments
+        formatted_query = "Test query about science Return the response with xml tags <answer> and <citations>, where citations includes a list with the citation_number, url, and timestamp for the retrieved citations"
+        mock_agent.run_sync.assert_called_once_with(formatted_query)
+
+
+@pytest.mark.asyncio
+async def test_perplexity_query_custom_model(mock_agent, mock_openai_model):
+    """Test the perplexity_query function with a custom model."""
+    # Setup the mock
+    mock_result = MagicMock()
+    mock_result.data = """
+    <answer>Custom model response</answer>
+    <citations>
+      <citation>
+        <citation_number>1</citation_number>
+        <url>https://example.com/citation1</url>
+      </citation>
+    </citations>
+    """
+    mock_agent.run_sync.return_value = mock_result
+    
+    # Set environment variable for test
+    with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test_key"}):
+        # Call the function with custom model
+        result = await perplexity_query("Test query", model_name="sonar-pro")
+        
+        # Verify the result
+        assert "Custom model response" in result.content
+        assert len(result.citations) == 1
+        
+        # Verify the OpenAIModel was initialized with the correct model name
+        mock_openai_model.assert_called_once()
+        args, kwargs = mock_openai_model.call_args
+        assert kwargs["model_name"] == "sonar-pro"
+
+
+@pytest.mark.asyncio
+async def test_perplexity_query_missing_api_key():
+    """Test the perplexity_query function with a missing API key."""
+    # Set environment variable for test
+    with patch.dict(os.environ, {}, clear=True):
+        # Call the function and expect an exception
+        with pytest.raises(ValueError) as excinfo:
+            await perplexity_query("Test query")
+        
+        # Verify the exception message
+        assert "PERPLEXITY_API_KEY environment variable is not set" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_perplexity_query_empty_response(mock_agent, mock_openai_model):
+    """Test the perplexity_query function with an empty response."""
+    # Setup the mock to return an empty response
+    mock_result = MagicMock()
+    mock_result.data = """
+    <answer></answer>
+    <citations></citations>
+    """
+    mock_agent.run_sync.return_value = mock_result
+    
+    # Set environment variable for test
+    with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test_key"}):
+        # Call the function
+        result = await perplexity_query("Test query")
+        
+        # Verify the result
+        assert result.content == ""
+        assert len(result.citations) == 0
+
+
+@pytest.mark.asyncio
+async def test_perplexity_query_parsing_error(mock_agent, mock_openai_model):
+    """Test the perplexity_query function with a response that causes a parsing error."""
+    # Setup the mock to return a malformed response
+    mock_result = MagicMock()
+    mock_result.data = "Malformed response with no XML tags"
+    mock_agent.run_sync.return_value = mock_result
+    
+    # Set environment variable for test
+    with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test_key"}):
+        # Call the function and expect an exception
+        with pytest.raises(RuntimeError) as excinfo:
+            await perplexity_query("Test query")
+        
+        # Verify the exception message
+        assert "Failed to parse Perplexity response" in str(excinfo.value)
+
+
+# Integration tests (when not in CI environment)
+if os.getenv("GITHUB_ACTIONS") != "true" and os.getenv("PERPLEXITY_API_KEY"):
+    pytestmark = [
+        pytest.mark.integration,
+        pytest.mark.flaky(reruns=1, reruns_delay=2),
+    ]
+    
+    @pytest.mark.asyncio
+    async def test_perplexity_query_integration():
+        """Integration test for the perplexity_query function with real API calls."""
+        # Skip test if API key is not available
+        if not os.getenv("PERPLEXITY_API_KEY"):
+            pytest.skip("PERPLEXITY_API_KEY environment variable is not set")
+        
+        # Call the function
+        result = await perplexity_query("What is the capital of France?")
+        
+        # Verify the result
+        assert result.content is not None
+        assert "Paris" in result.content
+        assert isinstance(result.citations, list)

--- a/tests/test_agents/test_web_tools.py
+++ b/tests/test_agents/test_web_tools.py
@@ -66,8 +66,7 @@ async def test_perplexity_query(mock_agent, mock_openai_model):
         assert result.citations[1].url == "https://example.com/citation2"
         
         # Verify the mock was called with expected arguments
-        formatted_query = "Test query about science Return the response with xml tags <answer> and <citations>, where citations includes a list with the citation_number, url, and timestamp for the retrieved citations"
-        mock_agent.run_sync.assert_called_once_with(formatted_query)
+        mock_agent.run_sync.assert_called_once_with("Test query about science")
 
 
 @pytest.mark.asyncio
@@ -140,7 +139,7 @@ async def test_perplexity_query_parsing_error(mock_agent, mock_openai_model):
     """Test the perplexity_query function with a response that causes a parsing error."""
     # Setup the mock to return a malformed response
     mock_result = MagicMock()
-    mock_result.data = "Malformed response with no XML tags"
+    mock_result.data = "<malformed>XML that will cause parsing error"
     mock_agent.run_sync.return_value = mock_result
     
     # Set environment variable for test


### PR DESCRIPTION
## Summary
- Implements issue #64 adding `perplexity_query` function that returns a `ResultWithCitations` Pydantic model with content and citations
- Provides model parameterization with 'sonar' as default model
- Includes comprehensive test coverage for the new functionality

## Test plan
- Added thorough unit tests with mocked API responses
- Included optional integration test for environments with Perplexity API key configured

🤖 Generated with [Claude Code](https://claude.ai/code)