### PR TITLE
Replace SPARQLWrapper with requests library for ubergraph agent

### DIFF
--- a/src/aurelian/agents/ubergraph/ubergraph_tools.py
+++ b/src/aurelian/agents/ubergraph/ubergraph_tools.py
@@ -2,9 +2,9 @@
 Tools for interacting with the UberGraph SPARQL endpoint.
 """
 import asyncio
-import requests
 from typing import Any, Dict, List, Optional
 
+import requests
 from pydantic import BaseModel
 from pydantic_ai import RunContext, ModelRetry
 


### PR DESCRIPTION
## Summary
- Replaces SPARQLWrapper with Python's standard requests library in the ubergraph_tools.py file
- Resolves SSL verification issues on macOS reported in issue #83
- Maintains the same functionality while improving reliability

## Test plan
- Test with `poetry run aurelian ubergraph "what is the CL ID for macrophage"` to verify the agent correctly connects to the endpoint
- Ensure SPARQL queries execute successfully and return the expected results

Fixes #83